### PR TITLE
Updates lodash to v4.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "git-describe",
-  "version": "4.0.2",
+  "version": "4.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -148,9 +148,9 @@
       "dev": true
     },
     "lodash": {
-      "version": "4.17.10",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
-      "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
     },
     "minimatch": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "homepage": "https://github.com/tvdstaaij/node-git-describe#readme",
   "dependencies": {
-    "lodash": "^4.16.6"
+    "lodash": "^4.17.11"
   },
   "optionalDependencies": {
     "semver": "^5.3.0"


### PR DESCRIPTION
Updating lodash to v4.17.11 resolves two vulnaribilities CVE-2018-16487 and CVE-2018-3721.

~~However I wasn't able to run the tests as most of them already failed due to timeout before the update...~~ Nevermind, Travis succeeded. https://travis-ci.com/saitho/node-git-describe/jobs/176534138

* https://nvd.nist.gov/vuln/detail/CVE-2018-16487
* https://nvd.nist.gov/vuln/detail/CVE-2018-3721