### PR TITLE
fix(types): Add null/false as options for `match`, to not pass `--match` onwards

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -17,7 +17,7 @@ export type GitDescribeOptions = {
   long?: boolean;
   longSemver?: boolean;
   requireAnnotated?: boolean;
-  match?: string;
+  match?: null | false | string;
   customArguments?: Array<string>;
 };
 


### PR DESCRIPTION
Fix #20

Add `null` and `false` possible values to `match` option, in order to prevent any `--match` flag on the `git-describe` command.

Correctly handled by JS code (see #20)