### PR TITLE
build: Add github workflow script for tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: Build, lint, test
+
+on:
+  push:
+  pull_request:
+    branches: [master]
+
+jobs:
+
+  test:
+    strategy:
+      matrix:
+        os: ['ubuntu-latest', 'windows-latest', 'macos-latest']
+        node-version: [14.x, 16.x, 18.x]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: bash ci/test.sh
+        shell: bash
+     

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,4 @@
 .travis.yml
+.github
+ci
 test

--- a/ci/test.sh
+++ b/ci/test.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+# Bash strict mode, see https://betterprogramming.pub/top-tips-for-writing-unsurprising-bash-scripts-9b9f4f0cc30e
+# This is separate from the shebang so that it also works on windows
+set -e
+set -u
+
+# Install
+npm ci
+# Test
+npm run test


### PR DESCRIPTION
This PR adds a github actions workflow that tests on windows, macos and linux on all current releases of node (except 17, but that's a short lived version so I left it out).